### PR TITLE
Modified ota-ce capable of deploying to server with no change in functionality  

### DIFF
--- a/ota-ce.yaml
+++ b/ota-ce.yaml
@@ -9,20 +9,29 @@ services:
     # The official v2 Traefik docker image
     image: traefik:v2.3
     # Enables the web UI and tells Traefik to listen to docker
+#BEGIN REVERSE PROXY COMMAND
     command: --api.insecure=true --providers.docker --providers.docker.exposedbydefault=false
+#END REVERSE PROXY COMMAND
+#BEGIN REVERSE PROXY CERTIFICATES
+#END REVERSE PROXY CERTIFICATES
     ports:
       # The HTTP port
       - "80:80"
+#BEGIN REVERSE PROXY PORT
+#END REVERSE PROXY PORT
       # The Web UI (enabled by --api.insecure=true)
       - "8080:8080"
     volumes:
+#BEGIN REVERSE PROXY VOLUME
+#END REVERSE PROXY VOLUME
       # So that Traefik can listen to the Docker events
       - /var/run/docker.sock:/var/run/docker.sock
-
+#BEGIN LANDING PAGE CONTAINER
+#END LANDING PAGE CONTAINER
   gateway:
     image: nginx:1.13.7
     restart: always
-    command: ["nginx-debug", "-g", "daemon off;"]      
+    command: ["nginx-debug", "-g", "daemon off;"]
     expose:
       - '80'
       - '443'
@@ -67,6 +76,9 @@ services:
     command:
        - "/opt/ota-lith/bin/ota-lith"
        - "-Dconfig.file=/tmp/ota-lith.conf"
+#BEGIN NEW OTA LITH LABELS
+#END NEW OTA LITH LABELS
+#BEGIN OTA LITH LABELS
     labels:
       - traefik.enable=true
       - traefik.http.routers.reposerver.service=reposerver
@@ -87,10 +99,11 @@ services:
       - traefik.http.routers.campaigner.service=campaigner
       - traefik.http.routers.campaigner.rule=Host(`campaigner.ota.ce`)
       - traefik.http.services.campaigner.loadbalancer.server.port=7600
+#END OTA LITH LABELS
     volumes:
       - ./ota-lith-ce.conf:/tmp/ota-lith.conf
       - objects:/var/lib/ota-lith
-     
+
   ota-lith-daemons:
     image: uptane/ota-lith:latest
     restart: always

--- a/ota-ce.yaml
+++ b/ota-ce.yaml
@@ -4,6 +4,11 @@
 
 # TODO: Kafka
 
+#Using comments as markers to interact with ansible builtin block file modules to configure uptanedemo.org
+#To setup https using letsencrypt in reverse proxy container we use the  makers: REVERSE PROXY COMMAND, REVERSE PROXY CERTIFICATES, REVERSE PROXY PORT, REVERSE PROXY VOLUME
+#To setup the landing page for uptanedemo.org using an nginx container we use the  makerr:  LANDING PAGE CONTAINER
+#To setup the ota-lith services i.e. director, deviceregistry.. etc with reverse proxy we use the markers: OTA LITH LABELS  & NEW OTA LITH LABELS
+
 services:
   reverse-proxy:
     # The official v2 Traefik docker image

--- a/ota-ce/gateway.conf
+++ b/ota-ce/gateway.conf
@@ -1,7 +1,11 @@
 server {
     error_log  /var/log/nginx/error.log info;
     listen       8443 ssl;
+#BEGIN DGW NGINX CONF
+#END DGW NGINX CONF
+#BEGIN OTA CE NGINX CONF
     server_name ota.ce;
+#END OTA CE NGINX CONF
     ssl_certificate     /etc/ssl/gateway/server.chain.pem;
     ssl_certificate_key /etc/ssl/gateway/server.key;
     ssl_verify_client on;
@@ -32,14 +36,17 @@ server {
         proxy_set_header x-ats-namespace $deviceNamespace;
         proxy_pass http://ota-lith:7600;
     }
-
+#BEGIN DIRECTOR NGINX CONF
+#END DIRECTOR NGINX CONF
+#BEGIN OTA CE DIRECTOR
     location /director/ {
         rewrite ^/director/(.*)$ /api/v1/device/${deviceUuid}/$1 break;
         proxy_set_header x-ats-namespace $deviceNamespace;
         proxy_set_header Host director.ota.ce;
         proxy_pass http://reverse-proxy;
     }
-
+#END OTA CE DIRECTOR
+    
     location /repo/ {
         rewrite ^/repo/(.*)$ /api/v1/user_repo/$1 break;
         proxy_set_header x-ats-namespace $deviceNamespace;

--- a/scripts/gen-device.sh
+++ b/scripts/gen-device.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+#Using comments as markers to interact with ansible builtin block file modules to configure uptanedemo.org
+#To change how ota-ce-gen and cert directories are configured when interacting with uptanedemo.org, we use the markers:  CE DIR CONF and UPTANE DEMO DIR CONF 
+#To change how the script will interact with uptanedemo.org apis, we use the markers: UPTANE DEMO API CONF and  CE API CONF
+
 set -euo pipefail
 
 DEVICE_UUID=${DEVICE_UUID:-$(uuidgen | tr "[:upper:]" "[:lower:]")}

--- a/scripts/gen-device.sh
+++ b/scripts/gen-device.sh
@@ -4,8 +4,13 @@ set -euo pipefail
 
 DEVICE_UUID=${DEVICE_UUID:-$(uuidgen | tr "[:upper:]" "[:lower:]")}
 CWD=$(dirname "$0")
+
+#BEGIN UPTANE DEMO DIR CONF
+#END UPTANE DEMO DIR CONF
+#BEGIN CE DIR CONF
 SERVER_DIR=$CWD/../ota-ce-gen
 DEVICES_DIR=${SERVER_DIR}/devices
+#END CE DIR CONF
 
 device_id=$DEVICE_UUID
 device_dir="${DEVICES_DIR}/${DEVICE_UUID}"
@@ -18,7 +23,7 @@ openssl pkcs8 -topk8 -nocrypt -in "${device_dir}/pkey.ec.pem" -out "${device_dir
 openssl req -new -key "${device_dir}/pkey.pem" \
           -config <(sed "s/\$ENV::DEVICE_UUID/${DEVICE_UUID}/g" "${CWD}/certs/client.cnf") \
           -out "${device_dir}/${device_id}.csr"
-  
+
 openssl x509 -req -days 365 -extfile "${CWD}/certs/client.ext" -in "${device_dir}/${device_id}.csr" \
         -CAkey "${DEVICES_DIR}/ca.key" -CA "${DEVICES_DIR}/ca.crt" -CAcreateserial -out "${device_dir}/client.pem"
 
@@ -60,6 +65,11 @@ tls_clientcert_path = "client.pem"
 tls_pkey_path = "pkey.pem"
 EOF
 
+#BEGIN UPTANE DEMO API CONF
+#END UPTANE DEMO API CONF
+#BEGIN CE API CONF
 curl -X PUT -d "${body}" http://deviceregistry.ota.ce/api/v1/devices -s -S -v -H "Content-Type: application/json" -H "Accept: application/json, */*"
 
 echo "https://ota.ce:30443" > ${device_dir}/gateway.url
+#END CE API CONF
+

--- a/scripts/gen-server-certs.sh
+++ b/scripts/gen-server-certs.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# To generate server certs for uptanedemo.org , run the script like follows:
+#./gen-server-certs.sh uptanedemo.org  
 
 set -euo pipefail
 

--- a/scripts/gen-server-certs.sh
+++ b/scripts/gen-server-certs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SERVER_DIR=ota-ce-gen
 DEVICES_DIR=ota-ce-gen/devices
 CWD=$(dirname $0)
-SERVER_NAME=ota.ce
+SERVER_NAME=${1:-ota.ce}
 
 if [ -d "$SERVER_DIR" ] || [ -d "$DEVICES_DIR" ] ; then
     echo "${SERVER_DIR} or ${DEVICES_DIR} exists, aborting"

--- a/scripts/get-credentials.sh
+++ b/scripts/get-credentials.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+#Using comments as markers to interact with ansible builtin block file modules to configure uptanedemo.org
+# To configure apis when interacting with uptanedemo.org  we use the markers:  HTTPS and HTTP
+# ./get-credentials.sh https uptanedemo.org
+
 set -euox pipefail
 
 SERVER_DIR=ota-ce-gen

--- a/scripts/get-credentials.sh
+++ b/scripts/get-credentials.sh
@@ -3,15 +3,17 @@
 set -euox pipefail
 
 SERVER_DIR=ota-ce-gen
+SERVER_BASE_URI=${2:-ota.ce}
+
 
 namespace="x-ats-namespace:default"
-keyserver="keyserver.ota.ce"
-reposerver="reposerver.ota.ce"
-director="director.ota.ce"
+keyserver="${1:-http}://keyserver.${SERVER_BASE_URI}"
+reposerver="${1:-http}://reposerver.${SERVER_BASE_URI}"
+director="${1:-http}://director.${SERVER_BASE_URI}"
 
-curl --silent --fail ${director}/health || echo "$director not running"
-curl --silent --fail ${keyserver}/health || echo "$keyserver not running"
-curl --silent --fail ${reposerver}/health || echo "$reposerver not running"
+curl --silent --fail ${director}/health/version || echo "$director not running"
+curl --silent --fail ${keyserver}/health/version || echo "$keyserver not running"
+curl --silent --fail ${reposerver}/health/version || echo "$reposerver not running"
 
 curl -X POST "${reposerver}/api/v1/user_repo" -H "${namespace}"
 
@@ -29,16 +31,21 @@ keys=$(curl -s -f "${keyserver}/api/v1/root/${id}/keys/targets/pairs")
 echo ${keys} | jq '.[0] | {keytype, keyval: {public: .keyval.public}}'   > "${SERVER_DIR}/targets.pub"
 echo ${keys} | jq '.[0] | {keytype, keyval: {private: .keyval.private}}' > "${SERVER_DIR}/targets.sec"
 
-echo "http://reposerver.ota.ce" > "${SERVER_DIR}/tufrepo.url"
-echo "http://ota.ce:30443" > "${SERVER_DIR}/autoprov.url"
+#BEGIN HTTPS
+#END HTTPS
+
+#BEGIN HTTP
+echo "http://reposerver.${SERVER_BASE_URI}" > "${SERVER_DIR}/tufrepo.url"
+echo "http://${SERVER_BASE_URI}:30443" > "${SERVER_DIR}/autoprov.url"
 
 cat > "${SERVER_DIR}/treehub.json" <<END
 {
     "no_auth": true,
     "ostree": {
-        "server": "http://treehub.ota.ce/api/v3/"
+        "server": "http://treehub.${SERVER_BASE_URI}/api/v3/"
     }
 }
 END
+#END HTTP
 
 zip --quiet --junk-paths ${SERVER_DIR}/{credentials.zip,autoprov.url,server_ca.pem,tufrepo.url,targets.pub,targets.sec,treehub.json,root.json}


### PR DESCRIPTION
- ota-ce configured to demo uptane
- bash parameter substitution in gen-server-certs.sh and get-credentials.sh
- Markers for ansible blockinfile module in ota-ce.yaml, gateway.conf, gen-device.sh